### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ of any element of the webpage.<br/>
 In order to do that just put "scroll:true" to the animation attributes of any element.<br/>
 Example: <br/>
 <pre lang="css"><code>
-#section:myEvent{
+# section:myEvent{
     duration:300;
     scroll:true;
 }


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
